### PR TITLE
ci: add Firebase production deployment workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,38 @@
+name: 🚀 Deploy to Firebase (Production)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set up environment variables
+        run: cp env.local.example .env.local
+
+      - name: Build Next.js app
+        run: npm run build
+
+      - name: Authenticate with Google
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Deploy to Firebase
+        run: npx firebase-tools deploy --project internkontroll-8e12a --non-interactive


### PR DESCRIPTION
## Description
Adds a GitHub Actions workflow that automatically deploys the app to Firebase every time a PR is merged to main. No more manual deploys.

## Before this works, one thing needs to be done
Someone with access to the Firebase project needs to create a service account key and add it to GitHub:

1. Go to Google Cloud Console → project `internkontroll-8e12a`
2. IAM & Admin → Service Accounts → Create a new service account
3. Give it the role **Firebase Hosting Admin**
4. Download the JSON key
5. Go to this GitHub repo → Settings → Secrets and variables → Actions
6. Add new secret named `FIREBASE_SERVICE_ACCOUNT` and paste the JSON as the value