### PR TITLE
fix: show all subunit levels and restrict courses to parent customer

### DIFF
--- a/src/app/(dashboard)/customer-subunits/page.tsx
+++ b/src/app/(dashboard)/customer-subunits/page.tsx
@@ -339,9 +339,14 @@ const SubunitManager = ({ customer }: { customer: Customer }) => {
     () => [...subunits].sort((a, b) => a.companyName.localeCompare(b.companyName)),
     [subunits],
   );
+  const customerCourseIds = useMemo(
+    () => new Set(customer.courseIds ?? []),
+    [customer.courseIds],
+  );
   const availableCourses = useMemo(
     () =>
       courses
+        .filter((course) => customerCourseIds.has(course.id))
         .map((course) => ({
           id: course.id,
           title:
@@ -350,7 +355,7 @@ const SubunitManager = ({ customer }: { customer: Customer }) => {
               : course.title ?? t.common.untitled,
         }))
         .sort((a, b) => a.title.localeCompare(b.title)),
-    [courses, t.common.untitled],
+    [courses, customerCourseIds, t.common.untitled],
   );
 
   const openCreate = () => {
@@ -654,6 +659,9 @@ const SubunitManager = ({ customer }: { customer: Customer }) => {
                       }}
                       onFocus={() => {
                         if (suggestions.length) setShowSuggestions(true);
+                      }}
+                      onBlur={() => {
+                        setTimeout(() => setShowSuggestions(false), 200);
                       }}
                       className="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200"
                     />

--- a/src/hooks/useCustomerSubunits.ts
+++ b/src/hooks/useCustomerSubunits.ts
@@ -38,7 +38,7 @@ export const useCustomerSubunits = (
   const collectionRef = useMemo(() => collection(db, 'customers'), []);
 
   useEffect(() => {
-    if (!parentCustomerId) {
+    if (!parentCustomerId || !ownerCompanyId) {
       startTransition(() => {
         setSubunits([]);
         setLoading(false);
@@ -51,15 +51,15 @@ export const useCustomerSubunits = (
       setLoading(true);
     });
 
-    const q = query(collectionRef, where('parentCustomerId', '==', parentCustomerId));
+    const q = query(collectionRef, where('createdByCompanyId', '==', ownerCompanyId));
     const unsubscribe = onSnapshot(
       q,
       (snapshot) => {
-        const next: Customer[] = snapshot.docs.map((docSnap) => {
+        const all: Customer[] = snapshot.docs.map((docSnap) => {
           const data = docSnap.data();
           return {
             id: docSnap.id,
-            parentCustomerId: data.parentCustomerId ?? parentCustomerId,
+            parentCustomerId: data.parentCustomerId ?? null,
             parentCustomerName:
               typeof data.parentCustomerName === 'string'
                 ? data.parentCustomerName
@@ -83,7 +83,19 @@ export const useCustomerSubunits = (
             updatedAt: data.updatedAt?.toDate?.() ?? undefined,
           };
         });
-        setSubunits(next);
+
+        const descendantIds = new Set<string>();
+        const collectDescendants = (pid: string) => {
+          for (const c of all) {
+            if (c.parentCustomerId === pid && !descendantIds.has(c.id)) {
+              descendantIds.add(c.id);
+              collectDescendants(c.id);
+            }
+          }
+        };
+        collectDescendants(parentCustomerId);
+
+        setSubunits(all.filter((c) => descendantIds.has(c.id)));
         setLoading(false);
         setError(null);
       },
@@ -96,7 +108,7 @@ export const useCustomerSubunits = (
     );
 
     return () => unsubscribe();
-  }, [collectionRef, parentCustomerId]);
+  }, [collectionRef, parentCustomerId, ownerCompanyId]);
 
   const createSubunit = useCallback(
     async (payload: SubunitPayload) => {


### PR DESCRIPTION
## Description
show all subunit levels and restrict courses to parent customer

## Screenshots
<img width="1282" height="537" alt="image" src="https://github.com/user-attachments/assets/452a5734-151d-45e0-a0c9-a72f506e5bbe" />