### PR TITLE
fix: preserve subunit parent on edit (#64)

### DIFF
--- a/src/app/(dashboard)/customer-subunits/page.tsx
+++ b/src/app/(dashboard)/customer-subunits/page.tsx
@@ -472,8 +472,12 @@ const SubunitManager = ({ customer }: { customer: Customer }) => {
         contactPerson: customerValues.contactPerson.trim(),
         contactEmail: customerValues.contactEmail.trim(),
         allowSubunits: customerValues.allowSubunits ?? false,
-        parentCustomerId: customer.id,
-        parentCustomerName: customer.companyName,
+        parentCustomerId: editingCustomer
+          ? (editingCustomer.parentCustomerId ?? null)
+          : customer.id,
+        parentCustomerName: editingCustomer
+          ? (editingCustomer.parentCustomerName ?? null)
+          : customer.companyName,
       };
 
       if (editingCustomer) {

--- a/src/app/(dashboard)/customers/CustomerManager.tsx
+++ b/src/app/(dashboard)/customers/CustomerManager.tsx
@@ -364,7 +364,15 @@ export default function CustomerManager() {
     try {
       setBusy(true);
       setFormError(null);
-      const payload: CustomerPayload = { ...customerValues };
+      const payload: CustomerPayload = {
+        ...customerValues,
+        parentCustomerId: editingCustomer
+          ? (editingCustomer.parentCustomerId ?? null)
+          : null,
+        parentCustomerName: editingCustomer
+          ? (editingCustomer.parentCustomerName ?? null)
+          : null,
+      };
 
       if (editingCustomer) {
         await updateCustomer(editingCustomer.id, payload);


### PR DESCRIPTION
## Description

When editing a subunit, `parentCustomerId` and `parentCustomerName` were always overwritten with the root customer's values, causing nested subunits to lose their original parent on save. The fix preserves the existing parent fields when editing.

Closes #64

## Screenshots

**Before**

Bakeriet AS and Klesbutikken AS appeared at root level after being edited, their parent (Kjøpesenteret AS) was lost.
<img width="1019" height="440" alt="Image" src="https://github.com/user-attachments/assets/1a72e080-9071-4a55-bbc1-75dcdbd56da4" />

**After**

All subunits retain their correct parent after editing.
<img width="1560" height="1059" alt="image" src="https://github.com/user-attachments/assets/ed992ab3-346d-4b07-8758-070780270655" />


## Checklist

**General**

- [x]  Code builds without errors (`npm run build`)
- [x]  No new TypeScript errors
- [x]  No console errors or warnings introduced
- [x]  Existing functionality is not broken

**UI / UX**

- [ ]  Tested on phone, tablet, and desktop
- [x]  Color contrast meets WCAG AA
- [ ]  Screen reader tested

**Security & data**

- [x]  No sensitive data exposed in client code or logs
- [x]  Firestore rules cover any new read/write paths