### PR TITLE
feat: remove list row thumbnails and add load more to media library (…

### DIFF
--- a/src/app/(dashboard)/media/page.tsx
+++ b/src/app/(dashboard)/media/page.tsx
@@ -135,6 +135,7 @@ export default function MediaLibraryPage() {
   const [dragOverId, setDragOverId] = useState<string | null>(null);
   const [draggingIds, setDraggingIds] = useState<Set<string>>(new Set());
   const [syncingRefs, setSyncingRefs] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(20);
 
   const replaceInputRef = useRef<HTMLInputElement | null>(null);
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
@@ -360,6 +361,7 @@ export default function MediaLibraryPage() {
   useEffect(() => { void loadFolder(currentFolderId); }, [currentFolderId, loadFolder]);
   useEffect(() => { void loadAllFolders(); }, [loadAllFolders]);
   useEffect(() => { void loadModuleRefs(); }, [loadModuleRefs]);
+  useEffect(() => { setVisibleCount(20); }, [currentFolderId, filter, search]);
 
   const reload = useCallback(() => {
     void loadFolder(currentFolderId);
@@ -400,6 +402,8 @@ export default function MediaLibraryPage() {
 
     return items;
   }, [assets, folders, filter, search]);
+
+  const visibleItems = useMemo(() => listItems.slice(0, visibleCount), [listItems, visibleCount]);
 
   /* ---- Delete ---- */
   const handleDeleteAsset = useCallback(async (asset: LibraryAsset) => {
@@ -755,14 +759,14 @@ export default function MediaLibraryPage() {
       const end = Math.max(focusedIndex, index);
       const ids = new Set<string>();
       for (let i = start; i <= end; i++) {
-        const it = listItems[i];
+        const it = visibleItems[i];
         ids.add(it._kind === 'folder' ? it.id : ((it as LibraryAsset).libraryDocId ?? it.id));
       }
       setSelectedIds(ids);
     } else {
       setSelectedIds(new Set([itemId]));
     }
-  }, [focusedIndex, listItems]);
+  }, [focusedIndex, visibleItems]);
 
   const handleRowDoubleClick = useCallback((item: ListItem) => {
     if (item._kind === 'folder') {
@@ -816,14 +820,14 @@ export default function MediaLibraryPage() {
     // Don't handle when typing in search
     if ((e.target as HTMLElement).tagName === 'INPUT') return;
 
-    const focusedItem = focusedIndex >= 0 && focusedIndex < listItems.length ? listItems[focusedIndex] : null;
+    const focusedItem = focusedIndex >= 0 && focusedIndex < visibleItems.length ? visibleItems[focusedIndex] : null;
 
     switch (e.key) {
       case 'ArrowDown': {
         e.preventDefault();
-        const next = Math.min(focusedIndex + 1, listItems.length - 1);
+        const next = Math.min(focusedIndex + 1, visibleItems.length - 1);
         setFocusedIndex(next);
-        const it = listItems[next];
+        const it = visibleItems[next];
         if (it) setSelectedIds(new Set([it._kind === 'folder' ? it.id : ((it as LibraryAsset).libraryDocId ?? it.id)]));
         break;
       }
@@ -831,7 +835,7 @@ export default function MediaLibraryPage() {
         e.preventDefault();
         const prev = Math.max(focusedIndex - 1, 0);
         setFocusedIndex(prev);
-        const it = listItems[prev];
+        const it = visibleItems[prev];
         if (it) setSelectedIds(new Set([it._kind === 'folder' ? it.id : ((it as LibraryAsset).libraryDocId ?? it.id)]));
         break;
       }
@@ -906,13 +910,13 @@ export default function MediaLibraryPage() {
       case 'a': {
         if (e.ctrlKey || e.metaKey) {
           e.preventDefault();
-          const allIds = new Set(listItems.map((it) => it._kind === 'folder' ? it.id : ((it as LibraryAsset).libraryDocId ?? it.id)));
+          const allIds = new Set(visibleItems.map((it) => it._kind === 'folder' ? it.id : ((it as LibraryAsset).libraryDocId ?? it.id)));
           setSelectedIds(allIds);
         }
         break;
       }
     }
-  }, [focusedIndex, listItems, renamingId, handleRowDoubleClick, selectedIds, cutIds, handlePaste, handleUpload]);
+  }, [focusedIndex, visibleItems, renamingId, handleRowDoubleClick, selectedIds, cutIds, handlePaste, handleUpload]);
 
   /* ---- Filter buttons ---- */
   const filterButtons: { key: FilterType; label: string }[] = [
@@ -1130,7 +1134,7 @@ export default function MediaLibraryPage() {
 
               {/* Rows */}
               <div data-list-bg>
-                {listItems.map((item, index) => {
+                {visibleItems.map((item, index) => {
                   const itemId = item._kind === 'folder' ? item.id : ((item as LibraryAsset).libraryDocId ?? item.id);
                   const isSelected = selectedIds.has(itemId);
                   const isFocused = focusedIndex === index;
@@ -1165,12 +1169,7 @@ export default function MediaLibraryPage() {
                       `}>
                       <div className="flex items-center gap-3 overflow-hidden">
                         <span className="flex h-9 w-9 shrink-0 items-center justify-center">
-                          {item._kind === 'asset' && item.type === 'image' ? (
-                            <Image src={item.url} alt={name} width={36} height={36}
-                              className="h-9 w-9 rounded object-cover" />
-                          ) : (
-                            getTypeIcon(item._kind === 'folder' ? 'folder' : (item as LibraryAsset).type)
-                          )}
+                          {getTypeIcon(item._kind === 'folder' ? 'folder' : (item as LibraryAsset).type)}
                         </span>
                         {renamingId === itemId ? (
                           <input ref={renameInputRef}
@@ -1200,7 +1199,7 @@ export default function MediaLibraryPage() {
           ) : (
             /* Grid view */
             <div data-list-bg className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-3 p-3">
-              {listItems.map((item, index) => {
+              {visibleItems.map((item, index) => {
                 const itemId = item._kind === 'folder' ? item.id : ((item as LibraryAsset).libraryDocId ?? item.id);
                 const isSelected = selectedIds.has(itemId);
                 const isFocused = focusedIndex === index;
@@ -1261,6 +1260,19 @@ export default function MediaLibraryPage() {
               })}
             </div>
           )}
+        </div>
+      )}
+
+      {listItems.length > visibleCount && (
+        <div className="flex flex-col items-center gap-2 pt-1">
+          <p className="text-xs text-slate-400">{ml.showingOf(visibleCount, listItems.length)}</p>
+          <button
+            type="button"
+            onClick={() => setVisibleCount((c) => c + 20)}
+            className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+          >
+            {ml.loadMore}
+          </button>
         </div>
       )}
 

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -255,6 +255,8 @@ export const translations = {
         viewList: 'Listevisning',
         viewGrid: 'Rutenettvisning',
         itemsSelected: (n: number) => n === 1 ? '1 element valgt' : `${n} elementer valgt`,
+        loadMore: 'Last inn flere',
+        showingOf: (shown: number, total: number) => `Viser ${shown} av ${total}`,
       },
       brokenMedia: {
         replaceButton: 'Erstatt bilde',
@@ -1082,6 +1084,8 @@ export const translations = {
         viewList: 'List view',
         viewGrid: 'Grid view',
         itemsSelected: (n: number) => n === 1 ? '1 item selected' : `${n} items selected`,
+        loadMore: 'Load more',
+        showingOf: (shown: number, total: number) => `Showing ${shown} of ${total}`,
       },
       brokenMedia: {
         replaceButton: 'Replace image',


### PR DESCRIPTION
## Description

Removes image thumbnail previews from list view rows in the media library to reduce network requests on page load. Adds "load more" with 20 items shown initially resets on folder navigation, filter, and search changes.

Closes #63

## Screenshots

**Before**

Each image row triggered a full image load on mount, causing slow initial render.
<img width="1557" height="1124" alt="Screenshot 2026-05-24 174012" src="https://github.com/user-attachments/assets/f914aba1-5ff0-4a3d-aee9-4c21e90a8ece" />
**After**

List rows show type icons only. Grid view retains full image previews. "Viser X av Y / Last inn flere" button appears when there are more than 20 items.
<img width="1563" height="1137" alt="Screenshot 2026-05-24 174043" src="https://github.com/user-attachments/assets/a293aa22-2f16-40c8-8c32-f5285f2e028a" />

## Checklist

**General**

- [x]  Code builds without errors (`npm run build`)
- [x]  No new TypeScript errors
- [x]  No new console warnings introduced
- [x]  Existing functionality not broken — grid view, filters, search, keyboard nav, drag/drop all unchanged

**UI / UX**

- [ ]  Tested on phone, tablet, and desktop
- [x]  Color contrast meets WCAG AA
- [ ]  Screen reader tested

**Security & data**

- [x]  No sensitive data exposed in client code or logs
- [x]  Firestore rules cover any new read/write paths